### PR TITLE
fixed missing session info causing 400 error on user create

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 const hbs = exphbs.create({  });
 
+//setup session so that password can be confirmed
 const sess = {
     secret: process.env.SESSION_PW,
     cookie: {},
@@ -29,7 +30,7 @@ app.use(routes);
 
 
 // sync sequelize models to the database, then turn on the server
-sequelize.sync({ force: true }).then(() => {
+sequelize.sync({ force: false }).then(() => {
     app.listen(PORT, () => console.log(`App listening on port http://localhost:${PORT}`));
 });
 

--- a/server.js
+++ b/server.js
@@ -3,23 +3,33 @@ const session = require('express-session');
 const exphbs = require('express-handlebars');
 const express = require('express');
 const routes = require('./controllers');
-// import sequelize connection
 const sequelize = require('./config/connection')
+const SequelizeStore = require('connect-session-sequelize')(session.Store);
 const app = express();
 const PORT = process.env.PORT || 3001;
 const hbs = exphbs.create({  });
 
+const sess = {
+    secret: process.env.SESSION_PW,
+    cookie: {},
+    resave: false,
+    saveUninitialized: true,
+    store: new SequelizeStore({
+      db: sequelize
+    })
+  };
+
+app.use(session(sess));
 app.use(express.static(path.join(__dirname, 'public')));
 app.engine('handlebars', hbs.engine);
 app.set('view engine', 'handlebars');
-
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-
 app.use(routes);
 
+
 // sync sequelize models to the database, then turn on the server
-sequelize.sync({ force: false }).then(() => {
+sequelize.sync({ force: true }).then(() => {
     app.listen(PORT, () => console.log(`App listening on port http://localhost:${PORT}`));
 });
 


### PR DESCRIPTION
In order to use the session info - some config had to be added back in to the server.js

to test - use this branch then use insomnia to create a new user. You should get a 200 response/the user correctly generated. Prior we were creating the user, but getting 400 errors + the session wasn't working.

Future - we will need to add password checks for the other routes/pages so that the password actually does something. Will add another task.