### PR TITLE
fixing console error with logout button

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -47,7 +47,9 @@
             Thanks for visiting!
         </footer>
     </div>
-    <script src="/javascript/logout.js"></script>
+  {{#if loggedIn}}
+  <script src="/javascript/logout.js"></script>
+  {{/if}}
 </body>
 
 </html>


### PR DESCRIPTION
Very small change and decided to push it up separately as it's easier to manage small PRs. This fixes a console log error with the logout button, as it will now only show/execute the logout code if the user is logged in.